### PR TITLE
Add simple Streamlit visual interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ We provide tutorials for:
 3. **examine the robustness for prompt attacks**, please refer to [examples/prompt_attack.ipynb](examples/prompt_attack.ipynb) to construct the attacks.
 4. **use DyVal for evaluation:** please refer to [examples/dyval.ipynb](examples/dyval.ipynb) to construct DyVal datasets.
 5. **efficient multi-prompt evaluation using PromptEval**: please refer to [examples/efficient_multi_prompt_eval.ipynb](examples/efficient_multi_prompt_eval.ipynb)
+6. **browse adversarial prompts through a simple interface**: run `python examples/visual_interface.py` to start a Streamlit app.
 
 ## Implemented Components
 

--- a/examples/visual_interface.py
+++ b/examples/visual_interface.py
@@ -1,0 +1,37 @@
+import streamlit as st
+import pandas as pd
+import os
+import re
+
+BASE_DIR = os.path.join(os.path.dirname(__file__), '..', 'promptbench', 'prompts', 'adv_prompts')
+
+st.title('PromptBench Adversarial Prompts Viewer')
+
+# List available md files
+def list_files():
+    files = [f for f in os.listdir(BASE_DIR) if f.endswith('.md') and f.lower() != 'readme.md']
+    files.sort()
+    return files
+
+@st.cache_data
+def load_prompts(filename):
+    path = os.path.join(BASE_DIR, filename)
+    pattern = re.compile(r"Acc: ([0-9.]+)%, prompt: (.*)")
+    records = []
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            m = pattern.match(line.strip())
+            if m:
+                records.append({'Accuracy': float(m.group(1)), 'Prompt': m.group(2)})
+    return pd.DataFrame(records)
+
+md_files = list_files()
+file_choice = st.selectbox('Select Model', md_files)
+
+if file_choice:
+    df = load_prompts(file_choice)
+    if df.empty:
+        st.write('No prompts found in', file_choice)
+    else:
+        st.write(df)
+        st.bar_chart(df['Accuracy'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ transformers_stream_generator==0.0.5
 torchvision==0.17.0
 matplotlib==3.8.3
 tiktoken==0.6.0
+streamlit==1.31.1


### PR DESCRIPTION
## Summary
- add `examples/visual_interface.py` for viewing adversarial prompts
- document how to launch the interface in the README
- add `streamlit` to dependencies

## Testing
- `python -m py_compile examples/visual_interface.py`


------
https://chatgpt.com/codex/tasks/task_e_6847e1d997e88324936267b41e54fdcf